### PR TITLE
Upscale test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,57 @@
+name: Build
+on:
+  pull_request:
+  workflow_dispatch:
+env:
+  DEBIAN_FRONTEND: noninteractive
+  TEMPORARY_DIRECTORY: /home/runner/work/_temp
+jobs:
+  preparation:
+    name: Preparation
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Create environment
+        run: |
+          echo "export DOCKER_TAG=\"${GITHUB_SHA}-$(date +'%Y%m%d-%H%M%S')\"" >> ./vars
+      - name: Persist environment
+        uses: actions/upload-artifact@v1
+        with:
+          name: environment
+          path: ./vars
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    needs: [preparation]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Fetch environment
+        uses: actions/download-artifact@v1
+        with:
+          name: environment
+      - name: Authenticate registry
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Configure system
+        run: |
+          # update packages & install requirements
+            sudo apt-get -qy update
+            sudo apt-get -qy install moreutils
+
+          # enable Dockers experimental features
+            if [[ -z "${DOCKER_CONFIG}" ]]; then
+              export DOCKER_CONFIG="${TEMPORARY_DIRECTORY}/docker.$(date +%s)"
+              mkdir -p ${DOCKER_CONFIG}
+              touch ${DOCKER_CONFIG}/config.json
+            fi
+
+            sudo sh -c "jq -s 'add' ${DOCKER_CONFIG}/config.json ./.docker/config.json | sponge ${DOCKER_CONFIG}/config.json"
+            sudo sh -c "jq . ./.docker/daemon.json | sponge /etc/docker/daemon.json"
+            sudo service docker restart
+      - name: Build image
+        run: |
+          source ./environment/vars
+
+          docker build --compress --no-cache --force-rm --squash -t miratmu/ffmpeg-tensorflow:${DOCKER_TAG} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,18 +44,18 @@ RUN set -e && bootstrap \
     ### prepare sr models
         && apt-get install -y python3 python3-pip git \
         && python3 -m pip install --upgrade pip \
-	&& pip3 install setuptools wheel \
-	&& pip3 install tensorflow==${VERSION_LIBTENSORFLOW} numpy \ 
-	&& git clone https://github.com/HighVoltageRocknRoll/sr \
-	&& cd sr \
-	&& python3 generate_header_and_model.py --model=espcn  --ckpt_path=checkpoints/espcn \
-	&& python3 generate_header_and_model.py --model=srcnn  --ckpt_path=checkpoints/srcnn \ 
-	&& python3 generate_header_and_model.py --model=vespcn --ckpt_path=checkpoints/vespcn \
-	&& python3 generate_header_and_model.py --model=vsrnet --ckpt_path=checkpoints/vsrnet \ 
-	&& mkdir /usr/models/ \
-	&& cp espcn.pb srcnn.pb vespcn.pb vsrnet.pb /usr/models/ \
-	&& cd .. \
-	&& rm -rf sr/ \
+        && pip3 install setuptools wheel \
+        && pip3 install tensorflow==${VERSION_LIBTENSORFLOW} numpy \
+        && git clone https://github.com/HighVoltageRocknRoll/sr \
+        && cd sr \
+        && python3 generate_header_and_model.py --model=espcn  --ckpt_path=checkpoints/espcn \
+        && python3 generate_header_and_model.py --model=srcnn  --ckpt_path=checkpoints/srcnn \
+        && python3 generate_header_and_model.py --model=vespcn --ckpt_path=checkpoints/vespcn \
+        && python3 generate_header_and_model.py --model=vsrnet --ckpt_path=checkpoints/vsrnet \
+        && mkdir /usr/models/ \
+        && cp espcn.pb srcnn.pb vespcn.pb vsrnet.pb /usr/local/share/ffmpeg-tensorflow-models/ \
+        && cd .. \
+        && rm -rf sr/ \
     ### persist dependencies
         && ldd /usr/local/bin/ffmpeg | tr -s '[:blank:]' '\n' | grep '^/' | xargs -I % sh -c 'mkdir -p $(dirname /deps%); cp % /deps%;' \
         && mv /usr/local/lib/libtensorflow* /deps/usr/local/lib \
@@ -77,8 +77,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 COPY script/ /usr/local/sbin/
 COPY --from=build /deps /
 COPY --from=build /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
-COPY --from=build /usr/models/ /usr/models/
+COPY --from=build /usr/local/share/ffmpeg-tensorflow-models/ /usr/local/share/ffmpeg-tensorflow-models/
 
-RUN set -e && bootstrap && finalize
+RUN set -e && ln -s /usr/local/share/ffmpeg-tensorflow-models/ /models && bootstrap && finalize
 
 ENTRYPOINT ["/usr/local/bin/ffmpeg"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN set -e && bootstrap \
         && python3 generate_header_and_model.py --model=srcnn  --ckpt_path=checkpoints/srcnn \
         && python3 generate_header_and_model.py --model=vespcn --ckpt_path=checkpoints/vespcn \
         && python3 generate_header_and_model.py --model=vsrnet --ckpt_path=checkpoints/vsrnet \
-        && mkdir /usr/models/ \
+        && mkdir /usr/local/share/ffmpeg-tensorflow-models/ \
         && cp espcn.pb srcnn.pb vespcn.pb vsrnet.pb /usr/local/share/ffmpeg-tensorflow-models/ \
         && cd .. \
         && rm -rf sr/ \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dockerfile that makes super-resolution in FFMpeg a breeze!
 
 ## Requirements
 
-- **[Miniconda][]**: For producing pre-trained super-resolution models.
+- **[Miniconda][]**: For producing pre-trained custom super-resolution models. (Optional)
 - **[Docker][]**: For running containerized FFMpeg with super-resolution support.
 - **[NVIDIA Container Toolkit][nvidia-docker]**: For GPU acceleration.
 
@@ -50,8 +50,16 @@ If you skip this section, a pre-build Docker image will be downloaded from
 [Docker Hub][docker-hub] when you try to upscale a video using
 super-resolution.
 
-## Prepare super-resolution models
 
+## Use super-resolution models build within docker image 
+
+Basic super-resolution models introduced in [the `HighVoltageRocknRoll/sr` GitHub
+repository][HighVoltageRocknRoll/sr] are already built and prepared in `/usr/models/` given 
+the tensorflow version provided.
+
+
+
+## Prepare super-resolution models (Optional)
 Create and activate a Miniconda environment named `ffmpeg-tensorflow`.
 Your version of the `tensorflow` package (here 1.15.0) should match the
 version of Libtensorflow that you used during installation:
@@ -107,13 +115,13 @@ ESPCN):
 $ wget https://media.xiph.org/video/derf/y4m/flower_cif.y4m
 $ alias ffmpeg-tensorflow='docker run --rm --gpus all -u $(id -u):$(id -g) -v "$PWD":/data -w /data -it miratmu/ffmpeg-tensorflow'
 $ ffmpeg-tensorflow -i flower_cif.y4m -filter_complex '
->   [0:v] format=pix_fmts=yuv420p, extractplanes=y+u+v [y][u][v];
->   [y] sr=dnn_backend=tensorflow:scale_factor=2:model=espcn.pb [y_scaled];
->   [u] scale=iw*2:ih*2 [u_scaled];
->   [v] scale=iw*2:ih*2 [v_scaled];
->   [y_scaled][u_scaled][v_scaled] mergeplanes=0x001020:yuv420p [merged]
-> ' -map [merged] -sws_flags lanczos -c:v libx264 -crf 17 -c:a copy \
-> -y flower_cif_2x.mp4
+[0:v] format=pix_fmts=yuv420p, extractplanes=y+u+v [y][u][v];
+[y] sr=dnn_backend=tensorflow:scale_factor=2:model=/usr/models/espcn.pb [y_scaled];
+[u] scale=iw*2:ih*2 [u_scaled];
+[v] scale=iw*2:ih*2 [v_scaled];
+[y_scaled][u_scaled][v_scaled] mergeplanes=0x001020:yuv420p [merged]
+' -map [merged] -sws_flags lanczos -c:v libx264 -crf 17 -c:a copy \
+-y flower_cif_2x.mp4
 ```
 
 The `flower_cif_2x.mp4` file with the upscaled example video should be produced.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ wget https://media.xiph.org/video/derf/y4m/flower_cif.y4m
 $ alias ffmpeg-tensorflow='docker run --rm --gpus all -u $(id -u):$(id -g) -v "$PWD":/data -w /data -it miratmu/ffmpeg-tensorflow'
 $ ffmpeg-tensorflow -i flower_cif.y4m -filter_complex '
 [0:v] format=pix_fmts=yuv420p, extractplanes=y+u+v [y][u][v];
-[y] sr=dnn_backend=tensorflow:scale_factor=2:model=/usr/models/espcn.pb [y_scaled];
+[y] sr=dnn_backend=tensorflow:scale_factor=2:model=/models/espcn.pb [y_scaled];
 [u] scale=iw*2:ih*2 [u_scaled];
 [v] scale=iw*2:ih*2 [v_scaled];
 [y_scaled][u_scaled][v_scaled] mergeplanes=0x001020:yuv420p [merged]


### PR DESCRIPTION
The docker image build now contains preparing basic super-resolution models found [HERE](https://github.com/HighVoltageRocknRoll/sr). 

[README.md prepare sr models section](https://github.com/MIR-MU/ffmpeg-tensorflow#prepare-super-resolution-models) was changed to optional, and as models are stored in /usr/models/, running command is slightly modified with correct path [Using upscaling](https://github.com/MIR-MU/ffmpeg-tensorflow#upscale-a-video-using-super-resolution)